### PR TITLE
Add Object's static Destroy-based Methods

### DIFF
--- a/Runtime/OnEvent.cs
+++ b/Runtime/OnEvent.cs
@@ -2,6 +2,8 @@
 using UnityEngine;
 using UnityEngine.Events;
 
+using Object = UnityEngine.Object;
+
 public class OnEvent : MonoBehaviour
 {
     [SerializeField] private EventTrigger _eventTrigger = EventTrigger.None;
@@ -316,5 +318,20 @@ public class OnEvent : MonoBehaviour
         {
             Destroy(this);
         }
+    }
+    
+    public new void Destroy(Object obj)
+    {
+        Object.Destroy(obj);
+    }
+
+    public new void DestroyImmediate(Object obj)
+    {
+        Object.DestroyImmediate(obj);
+    }
+
+    public new void DontDestroyOnLoad(Object target)
+    {
+        Object.DontDestroyOnLoad(target);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.caseydecoder.onevent",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "displayName": "On Event",
   "description": "A simple component that sends UnityEvents on Unity Messages (e.g. OnEnable).",
   "unity": "2019.3",


### PR DESCRIPTION
This allows for OnEvent to call Destroy, DestroyImmediate and DontDestroyOnLoad from a Unity Event. A good use case would be if you have some Editor Only game objects that you want to clean up during gameplay.